### PR TITLE
Dev console master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.quarkiverse.loggingui/quarkus-logging-ui?color=cool-green&style=flat-square)](https://mvnrepository.com/artifact/io.quarkiverse.loggingui/quarkus-logging-ui)
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?color=cool-green&style=flat-square)](#contributors-)
 
-This is the alpha version of the Quarkus Logging UI Extension, it provides you endpoints to visualize and manage the
+The Quarkus Logging UI Extension provides you endpoints to visualize and manage the
 log level of your loggers.
-Currently, there is no authentication/authorization mechanisms in place to protect from unauthorized access, in this 
-alpha version you have to protect this endpoint by yourself. 
 
 | Endpoint        | Http Method           | Description  |
 | ------------- |:-------------:|:-----:|

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -46,10 +46,20 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonb-deployment</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-swagger-ui-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
         </dependency>
         
         <dependency>

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiConfig.java
@@ -25,4 +25,8 @@ public class LoggingUiConfig {
     @ConfigItem
     @ConfigDocSection
     LoggingUiUIConfig ui;
+
+    public LoggingUiUIConfig getUi() {
+        return ui;
+    }
 }

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiOpenAPIFilter.java
@@ -34,7 +34,7 @@ import io.smallrye.openapi.api.models.responses.APIResponsesImpl;
  * Create OpenAPI entries (if configured)
  */
 public class LoggingUiOpenAPIFilter implements OASFilter {
-    private static final List<String> LOGGING_UI_TAG = Collections.singletonList("Logging UI");
+    public static final List<String> LOGGING_UI_TAG = Collections.singletonList("Logging UI");
     private static final String CONTENT_TYPE = "application/json";
     private static final String REF_LOGGER_INFO = "#/components/schemas/LoggerInfo";
     private static final String REF_LIST_LOGGER_INFO = "#/components/schemas/ListLoggerInfo";

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiUIConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiUIConfig.java
@@ -19,4 +19,8 @@ public class LoggingUiUIConfig {
      */
     @ConfigItem(defaultValue = "false")
     boolean alwaysInclude;
+
+    public String getRootPath() {
+        return rootPath;
+    }
 }

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/devconsole/DevConsoleProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/devconsole/DevConsoleProcessor.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.loggingui.quarkus.logging.ui.deployment.devconsole;
+
+import java.util.Optional;
+
+import io.quarkiverse.loggingui.quarkus.logging.ui.deployment.LoggingUiConfig;
+import io.quarkiverse.loggingui.quarkus.logging.ui.deployment.LoggingUiOpenAPIFilter;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
+import io.quarkus.swaggerui.spi.SwaggerUiBuildItem;
+
+public class DevConsoleProcessor {
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public DevConsoleTemplateInfoBuildItem loggersPath(LoggingUiConfig loggingUiConfig) {
+        return new DevConsoleTemplateInfoBuildItem("loggersPath", loggingUiConfig.getUi().getRootPath() + "/index.html");
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public DevConsoleTemplateInfoBuildItem swaggerUiPath(Optional<SwaggerUiBuildItem> swaggerUiBuildItemOptional) {
+        return swaggerUiBuildItemOptional
+                .map(SwaggerUiBuildItem::getSwaggerUiPath)
+                .map(swaggerUiDestination -> swaggerUiDestination + "/#/" + LoggingUiOpenAPIFilter.LOGGING_UI_TAG.get(0))
+                .map(path -> new DevConsoleTemplateInfoBuildItem("swaggerUiPath", path))
+                .orElse(new DevConsoleTemplateInfoBuildItem("swaggerUiPath", null));
+    }
+}

--- a/deployment/src/main/resources/dev-templates/embedded.html
+++ b/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,15 @@
+<a href="{info:loggersPath}" class="badge badge-light">
+	<svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-eye" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.134 13.134 0 0 0 1.66 2.043C4.12 11.332 5.88 12.5 8 12.5c2.12 0 3.879-1.168 5.168-2.457A13.134 13.134 0 0 0 14.828 8a13.133 13.133 0 0 0-1.66-2.043C11.879 4.668 10.119 3.5 8 3.5c-2.12 0-3.879 1.168-5.168 2.457A13.133 13.133 0 0 0 1.172 8z"></path>
+		<path fill-rule="evenodd" d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"></path>
+	</svg>
+	Logger Manager
+</a>
+{#if info:swaggerUiPath}
+<a href="{info:swaggerUiPath}" class="badge badge-light">
+	<svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-map" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" d="M15.817.113A.5.5 0 0 1 16 .5v14a.5.5 0 0 1-.402.49l-5 1a.502.502 0 0 1-.196 0L5.5 15.01l-4.902.98A.5.5 0 0 1 0 15.5v-14a.5.5 0 0 1 .402-.49l5-1a.5.5 0 0 1 .196 0L10.5.99l4.902-.98a.5.5 0 0 1 .415.103zM10 1.91l-4-.8v12.98l4 .8V1.91zm1 12.98l4-.8V1.11l-4 .8v12.98zm-6-.8V1.11l-4 .8v12.98l4-.8z"></path>
+	</svg>
+	Spec in Swagger Ui
+</a>
+{/if}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>1.10.3.Final</quarkus.version>
+        <quarkus.version>999-SNAPSHOT</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -9,7 +9,8 @@
     </parent>
 
     <artifactId>quarkus-logging-ui</artifactId>
-    <name>Quarkus - Logging UI - Runtime</name>
+    <name>Quarkus - Logging UI</name>
+    <description>Provides you endpoints to visualize and manage the log level of your loggers</description>
 
     <properties>
         <fomantic-ui.version>2.8.7</fomantic-ui.version>


### PR DESCRIPTION
This needs https://github.com/quarkusio/quarkus/pull/14265 to work.
I added the dev console card to our extension, it looks like this:
![image](https://user-images.githubusercontent.com/3311764/104387431-d91a8480-5515-11eb-8e28-a7c62615160b.png)

If the swagger-ui extension is not enabled, the lower link disappears.

I wanted to do something like this to the openapi specification (so the user can download the specification for this extension), but it seems that all endpoints (app and non-app) are packed in the same file, so I decided not to do it.

After we merge https://github.com/quarkiverse/quarkiverse-logging-manager/pull/26 and https://github.com/quarkiverse/quarkiverse-logging-manager/issues/15, this will need some refactoring.