### PR TITLE
Add this extension to the Dev Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.quarkiverse.loggingui/quarkus-logging-ui?color=cool-green&style=flat-square)](https://mvnrepository.com/artifact/io.quarkiverse.loggingui/quarkus-logging-ui)
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?color=cool-green&style=flat-square)](#contributors-)
 
-This is the alpha version of the Quarkus Logging UI Extension, it provides you endpoints to visualize and manage the
+The **Quarkus Logging Manager** Extension provides you endpoints to visualize and manage the
 log level of your loggers.
-Currently, there is no authentication/authorization mechanisms in place to protect from unauthorized access, in this 
-alpha version you have to protect this endpoint by yourself. 
 
 | Endpoint        | Http Method           | Description  |
 | ------------- |:-------------:|:-----:|

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiConfig.java
@@ -20,6 +20,12 @@ public class LoggingUiConfig {
     boolean openapiIncluded;
 
     /**
+     * The tag to use if OpenAPI is included
+     */
+    @ConfigItem(defaultValue = "Loggers")
+    String openapiTag;
+
+    /**
      * UI configuration
      */
     @ConfigItem

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiOpenAPIFilter.java
@@ -2,7 +2,6 @@ package io.quarkiverse.loggingui.quarkus.logging.ui.deployment;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -34,16 +33,17 @@ import io.smallrye.openapi.api.models.responses.APIResponsesImpl;
  * Create OpenAPI entries (if configured)
  */
 public class LoggingUiOpenAPIFilter implements OASFilter {
-    private static final List<String> LOGGING_UI_TAG = Collections.singletonList("Loggers");
     private static final String CONTENT_TYPE = "application/json";
     private static final String REF_LOGGER_INFO = "#/components/schemas/LoggerInfo";
     private static final String REF_LIST_LOGGER_INFO = "#/components/schemas/ListLoggerInfo";
     private static final String REF_LIST_STRING = "#/components/schemas/ListString";
 
     private final String basePath;
+    private final String tag;
 
-    public LoggingUiOpenAPIFilter(String basePath) {
+    public LoggingUiOpenAPIFilter(String basePath, String tag) {
         this.basePath = basePath;
+        this.tag = tag;
     }
 
     @Override
@@ -79,8 +79,8 @@ public class LoggingUiOpenAPIFilter implements OASFilter {
     private Operation createLevelsOperation() {
         Operation operation = new OperationImpl();
         operation.setDescription("This returns all possible log levels");
-        operation.setOperationId("loggerui_base_levels");
-        operation.setTags(LOGGING_UI_TAG);
+        operation.setOperationId("logging_manager_levels");
+        operation.setTags(Collections.singletonList(tag));
         operation.setSummary("Get all available levels");
         operation.setResponses(createLevelsAPIResponses());
         return operation;
@@ -123,8 +123,8 @@ public class LoggingUiOpenAPIFilter implements OASFilter {
     private Operation createLoggerPostOperation() {
         Operation operation = new OperationImpl();
         operation.setDescription("Update a log level for a certain logger");
-        operation.setOperationId("loggerui_update");
-        operation.setTags(LOGGING_UI_TAG);
+        operation.setOperationId("logging_manager_update");
+        operation.setTags(Collections.singletonList(tag));
         operation.setSummary("Update log level");
         operation.setResponses(createLoggerPostAPIResponses());
         operation.setRequestBody(createLoggersPostRequestBody());
@@ -164,8 +164,8 @@ public class LoggingUiOpenAPIFilter implements OASFilter {
     private Operation createLoggersOperation() {
         Operation operation = new OperationImpl();
         operation.setDescription("Get information on all loggers or a specific logger.");
-        operation.setOperationId("loggerui_base");
-        operation.setTags(LOGGING_UI_TAG);
+        operation.setOperationId("logging_manager_get_all");
+        operation.setTags(Collections.singletonList(tag));
         operation.setSummary("Information on Logger(s)");
         operation.setResponses(createLoggersAPIResponses());
         operation.addParameter(createLoggersParameter());

--- a/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingui/quarkus/logging/ui/deployment/LoggingUiProcessor.java
@@ -87,7 +87,7 @@ class LoggingUiProcessor {
         // Add to OpenAPI if OpenAPI is available
         if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
             LoggingUiOpenAPIFilter filter = new LoggingUiOpenAPIFilter(
-                    nonApplicationRootPathBuildItem.adjustPath(loggingUiConfig.basePath));
+                    nonApplicationRootPathBuildItem.adjustPath(loggingUiConfig.basePath), loggingUiConfig.openapiTag);
             openAPIProducer.produce(new AddToOpenAPIDefinitionBuildItem(filter));
         }
     }

--- a/deployment/src/main/resources/dev-templates/embedded.html
+++ b/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,11 @@
+<a href="{frameworkRootPath}{config:property('quarkus.logging-ui.ui.root-path')}" class="badge badge-light">
+  <i class="fa fa-file-text-o"></i>
+  Logging manager UI</a>
+<br>
+{#if config:property('quarkus.logging-ui.openapi.included') == 'true'}
+<a href="{frameworkRootPath}{config:property('quarkus.swagger-ui.path')}/#/{config:property('quarkus.logging-ui.openapi-tag')}" class="badge badge-light">
+  <i class="fa fa-map-signs fa-fw"></i>
+  Spec in Swagger UI</a>
+{/if}
+
+

--- a/deployment/src/main/resources/dev-templates/embedded.html
+++ b/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,5 +1,5 @@
 <a href="{frameworkRootPath}{config:property('quarkus.logging-ui.ui.root-path')}" class="badge badge-light">
-  <i class="fa fa-file-text-o"></i>
+  <i class="fas fa-file-alt"></i>
   Logging manager UI</a>
 <br>
 {#if config:property('quarkus.logging-ui.openapi.included') == 'true'}

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -9,8 +9,9 @@
     </parent>
 
     <artifactId>quarkus-logging-ui</artifactId>
-    <name>Quarkus - Logging UI - Runtime</name>
-
+    <name>Quarkus - Logging manager - Runtime</name>
+    <description>Provides you endpoints to visualize and manage the log level of your loggers</description>
+    
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: "Logging manager"
+metadata:
+  short-name: "logging manager"
+  keywords:
+  - "logging manager"
+  - "log"
+  - "logging levels"
+  - "log file"
+  categories:
+  - "logging"
+  status: "stable"


### PR DESCRIPTION
This PR supersede #30 and does not need https://github.com/quarkusio/quarkus/pull/14265

![image](https://user-images.githubusercontent.com/6836179/104709408-929c7400-5727-11eb-8a0d-8beb5b376bb3.png)


Changes include:

1) Moving the name of the openAPI tag to use to config with default of "Loggers"
2) Add `embedded.html ` that use the configured values to create the links, including a link to the swagger-ui if openapi filter is included.
3) Add `quarkus-extension.yaml` to name the extension (and not use the name in the pom)

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>